### PR TITLE
Skip double workflow run on release commit

### DIFF
--- a/release/action.yaml
+++ b/release/action.yaml
@@ -94,10 +94,7 @@ runs:
         # Commit the bumped project version with a non-semver chore: commit message
         git add pyproject.toml
         git --no-pager diff --staged
-        git commit --author="${{ inputs.git-user-name }} <${{ inputs.git-user-email }}>" -m "chore: release ${{ steps.version.outputs.new_release_version }}
-
-
-        skip-checks: true"
+        git commit --author="${{ inputs.git-user-name }} <${{ inputs.git-user-email }}>" -m "chore: release ${{ steps.version.outputs.new_release_version }}" -m "[skip actions]"
 
         # Push the changes to the current (should be main) branch, if this is not a dry-run
         # TODO: This might not be super safe, we should consider that this could


### PR DESCRIPTION
In order to use semantic release and populate the pyproject.toml, we need to push a commit to main to update the package version. For this commit we don't want to run actions again