### PR TITLE
Fix release to handle gracefully package version being right already

### DIFF
--- a/release/action.yaml
+++ b/release/action.yaml
@@ -94,6 +94,12 @@ runs:
         # Commit the bumped project version with a non-semver chore: commit message
         git add pyproject.toml
         git --no-pager diff --staged
+
+        #if there is no change in the version, exit with a warning
+        if [[ $(git diff --staged) == "" ]]; then
+          echo "::warning::No changes in version bump, exiting."
+          exit 0
+        fi
         git commit --author="${{ inputs.git-user-name }} <${{ inputs.git-user-email }}>" -m "chore: release ${{ steps.version.outputs.new_release_version }}" -m "[skip actions]"
 
         # Push the changes to the current (should be main) branch, if this is not a dry-run


### PR DESCRIPTION
In order for the empty commit to not cause issues when the package version is already matching the target one, exit when there is not git diff